### PR TITLE
refactor: split config in User and Core config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Intro
 
-We know emails are `VERY HARD` to develop.
-Sometimes you can use tool like Maiject, SendPulse, MailerSend, Stripo.email etc. Some if this have cool interface with drag and drop and different actions to do.
+We know emails are `VERY HARD` to develop from scratch.
+Sometimes you can use tool like Maiject, SendPulse, MailerSend, Stripo.email etc. Some of this have cool interfaces with drag and drop and different actions to do.
 
 So why you/your company should use this library?
 
+- you need to produce some html files using layouts and partials for different languages, passing them to a backend witch add maybe some data coming from itself (or another service) and fills your html files with its template engine.
+- backend of your company deploy email using with a custom service that use Amazon SES.
 - previous providers are not able to customize some parts. For example css rule. Or to do this is very complicated.
 - coming from [email-foundation-template](https://github.com/foundation/foundation-emails) and you want to try a different tool with advantages (please read below about features).
 - having complete control of development without use any Saas is mandatory.
-- the builded emails should be consumed by a backend service which use the emails again adding metadata coming from itself, or another api service for example. This scenario is the motivation which produced this library.
 
-Today market and opensource offers library that makes the development more easy. But each library/tools allow us to do a single thing without focus on a full development flow. This project wants to mix up MJML, a template engine for variables/logic and a web server, to create a tool able to generate emails with a simple flow and command. Please keep in mind that market offers some cool services like Maiject, SendPulse, MailerSend, Stripo.email etc so maybe you can find a fit with one of these solutions.
+This project wants to mix up MJML, a template engine for variables and a web server, to create a tool able to generate emails with a simple flow and one command. Please keep in mind that Maiject, SendPulse, MailerSend, Stripo.email etc maybe can be already perfect for your purpose.
 
 ## 🚀 Usage
 
@@ -20,29 +21,31 @@ Today market and opensource offers library that makes the development more easy.
 npm i marilena
 ```
 
-### How to use it
+### Setup
 
-0 - setup your `package.json`:
+marilena provides a command witch generate a small but working example with eta.js, variables, layout and partials. You can choose to generate this example adding these commands to your `package.json` and then run `npm run generate-example`.
 
 ```json
 "scripts": {
-  "start": "marilena --server",
-  "build": "marilena --build",
-  "example": "marilena --create-example", // if you run this script, it generates a working example, and then you can run start
+  "start": "marilena --server --project example/marilena.config.mjs",
+  "build": "marilena --build --project example/marilena.config.mjs",
+  "generate-example": "marilena --create-example",
 },
 ```
 
-1 - create a `marilena.config.mjs` file. Preferably under the root project:
+### Setup (manual)
+
+If you fails to generate the example or you want to build a project from 0 you need to crete `marilena.config.mjs` file in the root of your project. Please check below the fields since any of these are required.
 
 ```js
 import path from "path";
 // you can leverage your IDE's intellisense with jsdoc type hints
-/** @type {import('marilena').Config} */
+/** @type {import('marilena').UserConfig} */
 export default {
   inputFolder: "./input",
   outputFolder: "./output",
-  textVersion: (emailName, locale) => `${emailName}_text_version-${locale}.txt`, // is optional
-  htmlVersion: (emailName, locale) => `${emailName}-custom.html`, // is optional
+  textVersion: (emailName, locale) => `${emailName}_text_version-${locale}.txt`,
+  htmlVersion: (emailName, locale) => `${emailName}-custom.html`,
   locales: ["it", "en"],
   templateOptions: {
     engine: "eta",
@@ -58,16 +61,16 @@ export default {
 };
 ```
 
-1A - if you put `marilena.config.mjs` in a different path folder, or you did not generated a demo with `marilena --create-example` you have to update scripts:
+Edit you `package.json`. By default `marilena` try to find config in the root of your project. If you put the config in a different path, you need to pass `--project` argument in the scripts
 
 ```json
 "scripts": {
-  "start": "marilena --server --project myFolder/marilena.config.mjs",
-  "build": "marilena --build --project myFolder/marilena.config.mjs",
+  "start": "marilena --server",
+  "build": "marilena --build",
 },
 ```
 
-2 - create a file structures based on your config. Please remember that each email template requires `index.html` as name, and variables are loaded only from `variables.json` or `variables.yml`.
+create a file structures based on your config. Please remember that each email template requires `index.html` as name, and variables are loaded only from `variables.json` or `variables.yml`. Yes you can use both :)
 
 ```
 project
@@ -107,7 +110,7 @@ npm run start
 ```
 
 ```sh
-# build all emails based on config (template engine, output folder, and locales)
+# build all emails based on config
 npm run build
 ```
 
@@ -116,12 +119,12 @@ npm run build
 Under the hood a default configuration will be loaded but a file `marilena.config.mjs` allow us to set:
 | name | required | description | default |
 | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| inputFolder | X | folder where email are in the project. Path is relative to `marilena.config.mjs` | input |
-| outputFolder | X | folder used for generated email (when run build command). Path is relative to `marilena.config.mjs` | output |
-| locales | X | array of languages used. If you company has only spanish email use an array of single value | ["en"] |
+| inputFolder | | folder where email are in the project. Path is relative to `marilena.config.mjs` | ./input |
+| outputFolder | | folder used for generated email (when run build command). Path is relative to `marilena.config.mjs` | ./output |
+| locales | | array of languages used. If you need only spanish email use an array of single value | ["es"] |
 | templateOptions | | if you chose to use one of supported engines, this part is mandatory to setup custom partial and other settings for the template engine selected. Read below for some use cases | empty |
 | mjmlParsingOptions | | options passed to mjml render. See: [mjml options](https://www.npmjs.com/package/mjml) |
-| htmlVersion | | function of type `(emailName: string, locale: string) => string`. If set, this function allow to customize html version. The function must return file name `es: ${emailName}-${locale}.html` | index.html |
+| htmlVersion | | function of type `(emailName: string, locale: string) => string`. If set, this function allow to customize the output html filename. The function must return file name `es: ${emailName}-${locale}.html` | index.html |
 | textVersion | | function of type `(emailName: string, locale: string) => string`. If set, this function allow to generate text version of email stripping all html. The function must return file name `es: ${emailName}-${locale}-text-version.txt` |
 
 ## About templateOptions
@@ -186,9 +189,9 @@ If you want to add a css file import in `mj-include` tag. Path start from root d
 
 ## 🏗️ Roadmap (PRs are welcome 😀)
 
-- [ ] ejs, nunjucks, mustache, dot, liquid
+- [ ] liquid, ejs, nunjucks, mustache, dot
 - [ ] config in typescript
-- [ ] easy way to send a real email (AWS SES)
+- [ ] easy way to send a real email (AWS Ses/Nodemailer)
 - [ ] fast-refresh on config change
-- [ ] snaphost test for each email
+- [ ] snaphost test for each email out of the box
 - [ ] refactor to esm instead common js

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tsc && npm run copy && etsc && npm run generate-types",
     "copy": "mkdir -p dist/pages && cp src/pages/*.html dist/pages",
     "start": "node dist/server.js --project playground/marilena.config.mjs",
-    "start:example": "node dist/server.js --project marilena.config.mjs",
+    "start:example": "node dist/server.js --project example/marilena.config.mjs",
     "dev": "npm run copy && nodemon --project playground/marilena.config.mjs",
     "build-emails": "clear && npm run build && node ./dist/lib/buildAllEmails.js --project playground/marilena.config.mjs",
     "test": "npm run test:unit && npm run test:server && npm run test:example",

--- a/playground/marilena.config.mjs
+++ b/playground/marilena.config.mjs
@@ -3,10 +3,8 @@ import path from "path";
  * this is of config file. Is used only inside playground
  */
 
-/** @type {import('../').Config} */
+/** @type {import('../').UserConfig} */
 export default {
-  inputFolder: "./input",
-  outputFolder: "./output",
   textVersion: (emailName, locale) => `${emailName}_text_version-${locale}.txt`,
   locales: ["it", "en"],
   templateOptions: {

--- a/src/create-example.ts
+++ b/src/create-example.ts
@@ -26,7 +26,7 @@ fs.mkdirSync(fromPath, {
 });
 
 // 2 create marilena.config.mjs
-createConfig(rootFolder);
+createConfig(fromPath);
 
 // 3 create example/input example/ouuput
 createInpuFolder(fromPath);
@@ -46,10 +46,10 @@ createStyles(fromPath);
 
 logger.debug(
   `
-  I created a basic working example for you :). Check "marilena.config.mjs" file and "example folder.
+  I created a basic working example for you :). Check "example" folder.
   Now you can setup you script like this and run start command:
   "scripts": {
-    "start": "marilena --server"
+    "start": "marilena --server --project example/marilena.config.mjs"
   }
   `,
 );

--- a/src/create-example/create-config.ts
+++ b/src/create-example/create-config.ts
@@ -10,8 +10,8 @@ import path from "path";
 
 /** @type {import('marilena').Config} */
 export default {
-  inputFolder: "./example/input",
-  outputFolder: "./example/output",
+  inputFolder: "./input",
+  outputFolder: "./output",
   locales: ["en"],
   templateOptions: {
     engine: "eta",

--- a/src/lib/baseConfig.ts
+++ b/src/lib/baseConfig.ts
@@ -1,9 +1,9 @@
-import { Config } from "../types";
+import { CoreConfig } from "../types";
 
-const config: Config = {
-  inputFolder: "input",
-  outputFolder: "output",
+const coreConfig: CoreConfig = {
+  inputFolder: "./input",
+  outputFolder: "./output",
   locales: ["en"],
 };
 
-export default config;
+export default coreConfig;

--- a/src/lib/buildSingleWithConfig.ts
+++ b/src/lib/buildSingleWithConfig.ts
@@ -1,12 +1,12 @@
 import fs from "fs";
 import path from "path";
-import { Config } from "../types";
+import { CoreConfig, UserConfig } from "../types";
 import { inputOutputHtml } from "./inputOutputHtml";
 import { VARIABLES_LOADER } from "./loadVariables";
 import logger from "node-color-log";
 import { getPathConfig } from "../utils";
 
-export async function buildSingle(config: Config, emailName: string) {
+export async function buildSingle(config: CoreConfig, emailName: string) {
   const {
     inputFolder,
     outputFolder,

--- a/src/lib/buildWithConfig.ts
+++ b/src/lib/buildWithConfig.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
 import path from "path";
-import { Config } from "../types";
+import { CoreConfig } from "../types";
 import { buildSingle } from "./buildSingleWithConfig";
 import { getPathConfig, isEmailDirectory } from "../utils";
 
-export async function build(config: Config) {
+export async function build(config: CoreConfig) {
   const { inputFolder, outputFolder } = config;
 
   const inputFolderPath = path.resolve(getPathConfig(), "..", inputFolder);

--- a/src/lib/inputOutputHtml.ts
+++ b/src/lib/inputOutputHtml.ts
@@ -1,15 +1,15 @@
 import mjml2html from "mjml";
-import { Config } from "../types";
+import { CoreConfig } from "../types";
 import { CONFIG_FILE_NAME, SUPPORTED_ENGINES } from "../const";
 import { stripHtml } from "string-strip-html";
 
 const isTextExecution = process.env.NODE_ENV === "test";
 
 interface Options {
-  templateOptions?: Config["templateOptions"];
+  templateOptions?: CoreConfig["templateOptions"];
   inputHtml: string;
   variables: object;
-  mjmlParsingOptions: Config["mjmlParsingOptions"];
+  mjmlParsingOptions: CoreConfig["mjmlParsingOptions"];
   isTextVersion: boolean;
 }
 export async function inputOutputHtml({

--- a/src/lib/loadVariables.ts
+++ b/src/lib/loadVariables.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs";
-import { Config } from "../types";
+import { CoreConfig } from "../types";
 import {
   FILE_NAME_COMMON_VARIABLES,
   FILE_NAME_EMAIL_VARIABLES,
@@ -10,7 +10,7 @@ import yaml from "js-yaml";
 import { getPathConfig } from "../utils";
 
 interface Options {
-  config: Config;
+  config: CoreConfig;
   locale: string;
 }
 

--- a/src/lib/watcher.ts
+++ b/src/lib/watcher.ts
@@ -5,7 +5,7 @@ import {
   FILE_NAME_COMMON_VARIABLES,
   FILE_NAME_EMAIL_VARIABLES,
 } from "../const";
-import { Config } from "../types";
+import { CoreConfig } from "../types";
 import { getPathConfig } from "../utils";
 
 interface Callbacks {
@@ -15,7 +15,10 @@ interface Callbacks {
   handleEditCss: () => void;
 }
 
-export const setupWatcher = function (config: Config, callbacks: Callbacks) {
+export const setupWatcher = function (
+  config: CoreConfig,
+  callbacks: Callbacks,
+) {
   const { inputFolder } = config;
 
   const regex = new RegExp(`.*(.json|.yml|.html|.css|.eta|.hbs)`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { MJMLParsingOptions } from "mjml-core";
-export interface Config {
-  inputFolder: string; // default input
-  outputFolder: string; // default output
+export interface UserConfig {
+  inputFolder?: string; // default input
+  outputFolder?: string; // default output
   htmlVersion?: (emailName: string, locale: string) => string;
   textVersion?: (emailName: string, locale: string) => string;
   templateOptions?: {
@@ -9,8 +9,12 @@ export interface Config {
     // engineRoot will be handlebars,etc etc...
     prepareEngine: (engineRoot: unknown) => void;
   };
-  locales: string[]; // default ["en"]
+  locales?: string[]; // default ["en"]
   mjmlParsingOptions?: MJMLParsingOptions;
 }
 
 export type SupportedEngine = "eta" | "handlebars";
+
+// internal use only
+export type CoreConfig = UserConfig &
+  Required<Pick<UserConfig, "inputFolder" | "outputFolder" | "locales">>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Config } from "./types";
+import { UserConfig } from "./types";
 import baseConfig from "./lib/baseConfig";
 import logger from "node-color-log";
 import path from "path";
@@ -10,7 +10,7 @@ import argv from "minimist";
 export async function loadConfig() {
   try {
     const configDefault = await import(getPathConfig());
-    const config: Config = configDefault.default;
+    const config: UserConfig = configDefault.default;
 
     return {
       ...baseConfig,

--- a/test/buildWithConfig.test.ts
+++ b/test/buildWithConfig.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from "@jest/globals";
-import { Config } from "../src/types";
+import { CoreConfig } from "../src/types";
 import { build } from "../src/lib/buildWithConfig";
 import fs from "fs";
 import path from "path";
@@ -15,7 +15,7 @@ describe("writer correctly email files", () => {
   });
 
   test("create email with: [engine: NO, suffix: html, locale: en]", async () => {
-    const config: Config = {
+    const config: CoreConfig = {
       inputFolder: "test/basic_1/input",
       outputFolder: "test/basic_1/output",
       locales: ["en"],
@@ -32,7 +32,7 @@ describe("writer correctly email files", () => {
   });
 
   test("create email with: [engine: NO, suffix: html, locale: en] - custom htmlVersion", async () => {
-    const config: Config = {
+    const config: CoreConfig = {
       inputFolder: "test/basic_1/input",
       outputFolder: "test/basic_1/output",
       htmlVersion: (emailName, locale) => `${emailName}-${locale}.html`,
@@ -50,7 +50,7 @@ describe("writer correctly email files", () => {
   });
 
   test("create email with: [engine: eta, suffix: html, locale: en]", async () => {
-    const config: Config = {
+    const config: CoreConfig = {
       inputFolder: "test/eta_1/input",
       outputFolder: "test/eta_1/output",
       locales: ["en"],
@@ -80,7 +80,7 @@ describe("writer correctly email files", () => {
   });
 
   test("create email with: [engine: handlebars, suffix: html, locale: en]", async () => {
-    const config: Config = {
+    const config: CoreConfig = {
       inputFolder: "test/handlebars_1/input",
       outputFolder: "test/handlebars_1/output",
       locales: ["en"],
@@ -105,7 +105,7 @@ describe("writer correctly email files", () => {
   });
 
   test("create text version email", async () => {
-    const config: Config = {
+    const config: CoreConfig = {
       inputFolder: "test/text_version/input",
       outputFolder: "test/text_version/output",
       locales: ["en"],
@@ -132,7 +132,7 @@ describe("writer correctly email files", () => {
   test("create email with unsupported engine should throw error", async () => {
     expect.assertions(1);
 
-    const config: Config = {
+    const config: CoreConfig = {
       inputFolder: "test/handlebars_1/input",
       outputFolder: "test/handlebars_1/output",
       locales: ["en"],


### PR DESCRIPTION
splitting config in user config and core config is useful because project under the hood will merge initial user config with config that has all required fields